### PR TITLE
GamePickerStage: fixed FileChooser.ExtensionFilter parameters

### DIFF
--- a/src/main/java/com/github/bubb13/infinityareas/gui/stage/GamePickerStage.java
+++ b/src/main/java/com/github/bubb13/infinityareas/gui/stage/GamePickerStage.java
@@ -174,7 +174,7 @@ public class GamePickerStage extends Stage
         final FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Select Game Directory (chitin.key)");
         fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter(
-            "Infinity Engine Key File", "chitin.key"));
+            "Infinity Engine Key File", "*.key", ".KEY"));
 
         GlobalState.pushModalStage(null);
         final File selectedFile = fileChooser.showOpenDialog(this);


### PR DESCRIPTION
"File name extension should be specified in the *.<extension> format."
https://docs.oracle.com/javase/8/javafx/api/javafx/stage/FileChooser.ExtensionFilter.html#ExtensionFilter-java.lang.String-java.util.List-